### PR TITLE
refactor: move logic to utils and add try catch

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,43 +1,36 @@
 import { createContext, useEffect, useReducer, useState } from "react";
 import axios from "axios";
+import { initialContext, initialState, reducer } from "../utils/app-context";
 
-const getUsers = async () => {};
-
-const initialState = {
-  appTheme: "light",
-  themeHandler: () => {},
-  users: [],
-  favorites: [],
-};
-
-const appTheme = sessionStorage.getItem("theme");
-const themeHandler = (theme) => sessionStorage.setItem("theme", theme);
-const reducer = (state, action) => {
-  switch (action.type) {
-    case "theme":
-      return { ...state, appTheme: action.payload };
-    case "getUsers":
-      return { ...state, users: action.payload };
-  }
-};
-const AppContext = createContext(null);
+const AppContext = createContext(initialContext);
 
 export const AppProvider = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  useEffect(() => {
-    axios.get("https://jsonplaceholder.typicode.com/users").then(({ data }) => {
+  const getUsers = async () => {
+    try {
+      const { data } = await axios.get(
+        "https://jsonplaceholder.typicode.com/users"
+      );
       dispatch({ type: "getUsers", payload: data });
-    });
+    } catch (err) {
+      console.err("Hubo un error", err);
+    }
+  };
+
+  const themeHandler = (theme) => {
+    sessionStorage.setItem("theme", theme);
+    dispatch({ type: "theme", payload: theme });
+  };
+
+  useEffect(() => {
+    getUsers();
     dispatch({ type: "theme", payload: "dark" });
   }, []);
 
-  console.log("users", users, state);
-
   const properties = {
-    appTheme,
+    ...state,
     themeHandler,
-    users,
   };
   return (
     <AppContext.Provider value={properties}>{children}</AppContext.Provider>

--- a/src/utils/app-context.js
+++ b/src/utils/app-context.js
@@ -1,0 +1,18 @@
+const appTheme = sessionStorage.getItem("theme");
+
+export const initialState = {
+  appTheme: appTheme || "light",
+  users: [],
+  favorites: [],
+};
+
+export const initialContext = { ...initialState, themeHandler: () => {} };
+
+export const reducer = (state, action) => {
+  switch (action.type) {
+    case "theme":
+      return { ...state, appTheme: action.payload };
+    case "getUsers":
+      return { ...state, users: action.payload };
+  }
+};


### PR DESCRIPTION
Se distingue initialState de initialContext
Se agrega try catch al llamado a la api
Se mueve logica a archivo en utils para liberar espacio en el AppContext
En el themeHandler se ejecuta el dispatch del useReducer y tambien se setea key en sessionStorage
Por default buscamos el valor en sessionStorage para el AppTheme, sino existe ponemos 'light'